### PR TITLE
Remove Experimental Prefix from PMR on Linux, Builds With UE 5.6

### DIFF
--- a/Patches/Fast-CDR.patch
+++ b/Patches/Fast-CDR.patch
@@ -65,34 +65,22 @@ index 25c8055..2bc69f7 100644
                  endif()
              endif()
 diff --git a/include/fastcdr/Cdr.h b/include/fastcdr/Cdr.h
-index 6e7bae1..53c42c7 100644
+index 6e7bae1..4bf55b8 100644
 --- a/include/fastcdr/Cdr.h
 +++ b/include/fastcdr/Cdr.h
-@@ -23,12 +23,31 @@
- #include <vector>
+@@ -19,16 +19,17 @@
+ #include "FastBuffer.h"
+ #include "exceptions/NotEnoughMemoryException.h"
+ #include <stdint.h>
+-#include <string>
+-#include <vector>
  #include <map>
  #include <iostream>
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
 +#include <memory_resource>
 +#include <vector>
 +#include <string>
-+#endif
  
 -#if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+}
-+#endif
-+
 +#if !(defined(__APPLE__) && __APPLE__) && !(defined(__FreeBSD__) && __FreeBSD__) && !(defined(__VXWORKS__) && __VXWORKS__)
  #include <malloc.h>
  #else
@@ -102,7 +90,7 @@ index 6e7bae1..53c42c7 100644
  
  #if HAVE_CXX0X
  #include <array>
-@@ -470,8 +489,9 @@ public:
+@@ -470,8 +471,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -113,7 +101,7 @@ index 6e7bae1..53c42c7 100644
      {
          return serialize(string_t);
      }
-@@ -482,8 +502,9 @@ public:
+@@ -482,8 +484,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -124,7 +112,7 @@ index 6e7bae1..53c42c7 100644
      {
          return serialize(string_t);
      }
-@@ -510,11 +531,11 @@ public:
+@@ -510,11 +513,11 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -139,7 +127,7 @@ index 6e7bae1..53c42c7 100644
      }
  
      /*!
-@@ -735,8 +756,9 @@ public:
+@@ -735,8 +738,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -150,7 +138,7 @@ index 6e7bae1..53c42c7 100644
      {
          return deserialize(string_t);
      }
-@@ -747,8 +769,9 @@ public:
+@@ -747,8 +751,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -161,7 +149,7 @@ index 6e7bae1..53c42c7 100644
      {
          return deserialize(string_t);
      }
-@@ -775,11 +798,11 @@ public:
+@@ -775,11 +780,11 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -176,7 +164,7 @@ index 6e7bae1..53c42c7 100644
      }
  
      /*!
-@@ -1203,27 +1226,29 @@ public:
+@@ -1203,27 +1208,29 @@ public:
              Endianness endianness);
  
      /*!
@@ -210,7 +198,7 @@ index 6e7bae1..53c42c7 100644
      {
          return serialize(string_t.c_str());
      }
-@@ -1235,9 +1260,10 @@ public:
+@@ -1235,9 +1242,10 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -222,7 +210,7 @@ index 6e7bae1..53c42c7 100644
              Endianness endianness)
      {
          return serialize(string_t.c_str(), endianness);
-@@ -1281,9 +1307,9 @@ public:
+@@ -1281,9 +1289,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -234,7 +222,7 @@ index 6e7bae1..53c42c7 100644
      {
          return serializeBoolSequence(vector_t);
      }
-@@ -1296,9 +1322,9 @@ public:
+@@ -1296,9 +1304,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -246,7 +234,7 @@ index 6e7bae1..53c42c7 100644
      {
          state state_before_error(*this);
  
-@@ -1356,9 +1382,16 @@ public:
+@@ -1356,9 +1364,16 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -266,7 +254,7 @@ index 6e7bae1..53c42c7 100644
      {
          return serializeBoolSequence(vector_t);
      }
-@@ -1372,13 +1405,14 @@ public:
+@@ -1372,13 +1387,14 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -284,7 +272,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -1803,9 +1837,10 @@ public:
+@@ -1803,9 +1819,10 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -296,7 +284,7 @@ index 6e7bae1..53c42c7 100644
              size_t numElements)
      {
          for (size_t count = 0; count < numElements; ++count)
-@@ -1822,9 +1857,10 @@ public:
+@@ -1822,9 +1839,10 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -308,7 +296,7 @@ index 6e7bae1..53c42c7 100644
              size_t numElements)
      {
          for (size_t count = 0; count < numElements; ++count)
-@@ -1842,14 +1878,16 @@ public:
+@@ -1842,14 +1860,16 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -327,7 +315,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -1873,14 +1911,16 @@ public:
+@@ -1873,14 +1893,16 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -346,7 +334,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -1903,9 +1943,9 @@ public:
+@@ -1903,9 +1925,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
       */
@@ -358,7 +346,7 @@ index 6e7bae1..53c42c7 100644
              size_t numElements)
      {
          for (size_t count = 0; count < numElements; ++count)
-@@ -1949,7 +1989,8 @@ public:
+@@ -1949,7 +1971,8 @@ public:
              Endianness endianness)
      {
          bool auxSwap = m_swapBytes;
@@ -368,7 +356,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -2009,7 +2050,8 @@ public:
+@@ -2009,7 +2032,8 @@ public:
              Endianness endianness)
      {
          bool auxSwap = m_swapBytes;
@@ -378,7 +366,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -2426,18 +2468,19 @@ public:
+@@ -2426,18 +2450,19 @@ public:
              Endianness endianness);
  
      /*!
@@ -401,7 +389,7 @@ index 6e7bae1..53c42c7 100644
          return *this;
      }
  
-@@ -2447,12 +2490,14 @@ public:
+@@ -2447,12 +2472,14 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -418,7 +406,7 @@ index 6e7bae1..53c42c7 100644
          return *this;
      }
  
-@@ -2463,13 +2508,15 @@ public:
+@@ -2463,13 +2490,15 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -436,7 +424,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -2492,13 +2539,15 @@ public:
+@@ -2492,13 +2521,15 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -454,7 +442,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -2552,9 +2601,9 @@ public:
+@@ -2552,9 +2583,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -466,7 +454,7 @@ index 6e7bae1..53c42c7 100644
      {
          return deserializeBoolSequence(vector_t);
      }
-@@ -2567,9 +2616,9 @@ public:
+@@ -2567,9 +2598,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -478,7 +466,7 @@ index 6e7bae1..53c42c7 100644
      {
          uint32_t seqLength = 0;
          state state_before_error(*this);
-@@ -2645,9 +2694,16 @@ public:
+@@ -2645,9 +2676,16 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -498,7 +486,7 @@ index 6e7bae1..53c42c7 100644
      {
          return deserializeBoolSequence(vector_t);
      }
-@@ -2661,13 +2717,14 @@ public:
+@@ -2661,13 +2699,14 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -516,7 +504,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -3090,9 +3147,10 @@ public:
+@@ -3090,9 +3129,10 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -528,7 +516,7 @@ index 6e7bae1..53c42c7 100644
              size_t numElements)
      {
          for (size_t count = 0; count < numElements; ++count)
-@@ -3109,9 +3167,10 @@ public:
+@@ -3109,9 +3149,10 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -540,7 +528,7 @@ index 6e7bae1..53c42c7 100644
              size_t numElements)
      {
          for (size_t count = 0; count < numElements; ++count)
-@@ -3129,14 +3188,16 @@ public:
+@@ -3129,14 +3170,16 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -559,7 +547,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -3160,14 +3221,16 @@ public:
+@@ -3160,14 +3203,16 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -578,7 +566,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -3190,9 +3253,9 @@ public:
+@@ -3190,9 +3235,9 @@ public:
       * @return Reference to the eprosima::fastcdr::Cdr object.
       * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
       */
@@ -590,7 +578,7 @@ index 6e7bae1..53c42c7 100644
              size_t numElements)
      {
          for (size_t count = 0; count < numElements; ++count)
-@@ -3236,7 +3299,8 @@ public:
+@@ -3236,7 +3281,8 @@ public:
              Endianness endianness)
      {
          bool auxSwap = m_swapBytes;
@@ -600,7 +588,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -3379,7 +3443,8 @@ public:
+@@ -3379,7 +3425,8 @@ public:
              Endianness endianness)
      {
          bool auxSwap = m_swapBytes;
@@ -610,7 +598,7 @@ index 6e7bae1..53c42c7 100644
  
          try
          {
-@@ -3408,15 +3473,31 @@ private:
+@@ -3408,15 +3455,31 @@ private:
  
      Cdr& deserializeBoolSequence(
              std::vector<bool>& vector_t);

--- a/Patches/geometry2.patch
+++ b/Patches/geometry2.patch
@@ -840,36 +840,20 @@ index b84af48e..e66f3efa 100644
      NodeT && node,
      const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
 diff --git a/tf2_ros/include/tf2_ros/transform_listener.h b/tf2_ros/include/tf2_ros/transform_listener.h
-index 01620a8f..a8c55781 100644
+index 01620a8f..3cb68c35 100644
 --- a/tf2_ros/include/tf2_ros/transform_listener.h
 +++ b/tf2_ros/include/tf2_ros/transform_listener.h
-@@ -36,6 +36,25 @@
+@@ -36,6 +36,9 @@
  #include <memory>
  #include <thread>
  #include <utility>
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
 +#include <memory_resource>
 +#include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+}
-+#endif
  
  #include "tf2/buffer_core.h"
  #include "tf2/time.h"
-@@ -51,7 +70,7 @@ namespace tf2_ros
+@@ -51,7 +54,7 @@ namespace tf2_ros
  
  namespace detail
  {
@@ -878,7 +862,7 @@ index 01620a8f..a8c55781 100644
  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
  get_default_transform_listener_sub_options()
  {
-@@ -64,7 +83,7 @@ get_default_transform_listener_sub_options()
+@@ -64,7 +67,7 @@ get_default_transform_listener_sub_options()
    return options;
  }
  
@@ -887,7 +871,7 @@ index 01620a8f..a8c55781 100644
  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
  get_default_transform_listener_static_sub_options()
  {
-@@ -86,7 +105,7 @@ public:
+@@ -86,7 +89,7 @@ public:
    TF2_ROS_PUBLIC
    explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true);
  
@@ -896,7 +880,7 @@ index 01620a8f..a8c55781 100644
    TransformListener(
      tf2::BufferCore & buffer,
      NodeT && node,
-@@ -106,7 +125,7 @@ public:
+@@ -106,7 +109,7 @@ public:
    virtual ~TransformListener();
  
  private:

--- a/Patches/rmw_cyclonedds.patch
+++ b/Patches/rmw_cyclonedds.patch
@@ -1,36 +1,20 @@
 diff --git a/rmw_cyclonedds_cpp/src/TypeSupport.hpp b/rmw_cyclonedds_cpp/src/TypeSupport.hpp
-index be07c9e..596c57f 100644
+index be07c9e..9c0663b 100644
 --- a/rmw_cyclonedds_cpp/src/TypeSupport.hpp
 +++ b/rmw_cyclonedds_cpp/src/TypeSupport.hpp
-@@ -20,6 +20,27 @@
- #include <string>
- #include <functional>
+@@ -17,8 +17,10 @@
+ #define TYPESUPPORT_HPP_
  
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
+ #include <cassert>
+-#include <string>
+ #include <functional>
 +#include <memory_resource>
 +#include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+  using u16string = std::experimental::pmr::u16string;
-+}
-+#endif
-+
+ 
  #include "rcutils/logging_macros.h"
  
- #include "rosidl_runtime_c/string.h"
-@@ -89,16 +110,16 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
+@@ -89,16 +91,16 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
  template<>
  struct StringHelper<rosidl_typesupport_introspection_cpp::MessageMembers>
  {
@@ -52,38 +36,22 @@ index be07c9e..596c57f 100644
    }
  };
 diff --git a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
-index b4b890d..ff33e4b 100644
+index b4b890d..7f92a66 100644
 --- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
 +++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
-@@ -18,9 +18,26 @@
+@@ -18,9 +18,10 @@
  #include <functional>
  #include <memory>
  #include <regex>
 -#include <string>
  #include <utility>
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
 +#include <memory_resource>
  #include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+}
-+#endif
  
  #include "bytewise.hpp"
  #include "exception.hpp"
-@@ -437,7 +454,7 @@ public:
+@@ -437,7 +438,7 @@ public:
  class ROSIDLCPP_StringValueType : public U8StringValueType
  {
  public:
@@ -93,38 +61,21 @@ index b4b890d..ff33e4b 100644
    TypedSpan<const char_traits::char_type> data(const void * ptr) const override
    {
 diff --git a/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp b/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
-index 736e088..b5a2bd6 100644
+index 736e088..010533b 100644
 --- a/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
 +++ b/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
-@@ -18,8 +18,26 @@
+@@ -18,8 +18,9 @@
  
  #include <cassert>
  #include <functional>
 -#include <string>
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
 +#include <memory_resource>
  #include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+  using u16string = std::experimental::pmr::u16string;
-+}
-+#endif
  
  #include "TypeSupport.hpp"
  #include "macros.hpp"
-@@ -113,39 +131,39 @@ void deserialize_field(
+@@ -113,39 +114,39 @@ void deserialize_field(
    } else if (member->array_size_ && !member->is_upper_bound_) {
      deser.deserializeA(static_cast<T *>(field), member->array_size_);
    } else {
@@ -172,7 +123,7 @@ index 736e088..b5a2bd6 100644
    } else {
      uint32_t size;
      if (member->array_size_ && !member->is_upper_bound_) {
-@@ -156,7 +174,7 @@ inline void deserialize_field<std::wstring>(
+@@ -156,7 +157,7 @@ inline void deserialize_field<std::wstring>(
      }
      for (size_t i = 0; i < size; ++i) {
        void * element = member->get_function(field, i);
@@ -181,7 +132,7 @@ index 736e088..b5a2bd6 100644
        deser >> wstr;
        wstring_to_u16string(wstr, *u16str);
      }
-@@ -185,7 +203,7 @@ void deserialize_field(
+@@ -185,7 +186,7 @@ void deserialize_field(
  }
  
  template<>
@@ -190,7 +141,7 @@ index 736e088..b5a2bd6 100644
    const rosidl_typesupport_introspection_c__MessageMember * member,
    void * field,
    cycdeser & deser)
-@@ -198,7 +216,7 @@ inline void deserialize_field<std::string>(
+@@ -198,7 +199,7 @@ inline void deserialize_field<std::string>(
        auto deser_field = static_cast<rosidl_runtime_c__String *>(field);
        // tmpstring is defined here and not below to avoid
        // memory allocation in every iteration of the for loop
@@ -199,7 +150,7 @@ index 736e088..b5a2bd6 100644
        for (size_t i = 0; i < member->array_size_; ++i) {
          deser.deserialize(tmpstring);
          if (!rosidl_runtime_c__String__assign(&deser_field[i], tmpstring.c_str())) {
-@@ -206,7 +224,7 @@ inline void deserialize_field<std::string>(
+@@ -206,7 +207,7 @@ inline void deserialize_field<std::string>(
          }
        }
      } else {
@@ -208,7 +159,7 @@ index 736e088..b5a2bd6 100644
        deser >> cpp_string_vector;
  
        auto & string_array_field = *reinterpret_cast<rosidl_runtime_c__String__Sequence *>(field);
-@@ -230,12 +248,12 @@ inline void deserialize_field<std::string>(
+@@ -230,12 +231,12 @@ inline void deserialize_field<std::string>(
  }
  
  template<>
@@ -223,7 +174,7 @@ index 736e088..b5a2bd6 100644
    if (!member->is_array_) {
      deser >> wstr;
      wstring_to_u16string(
-@@ -307,10 +325,10 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
+@@ -307,10 +308,10 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
          deserialize_field<uint64_t>(member, field, deser);
          break;
        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
@@ -236,7 +187,7 @@ index 736e088..b5a2bd6 100644
          break;
        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
          {
-@@ -412,10 +430,10 @@ bool TypeSupport<MembersType>::printROSmessage(
+@@ -412,10 +413,10 @@ bool TypeSupport<MembersType>::printROSmessage(
          {uint64_t dummy; print_field(member, deser, dummy);}
          break;
        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
@@ -373,34 +324,19 @@ index 9973572..8c7a80e 100644
      const uint32_t sz = get_len(1);
      printA(x.data(), sz);
 diff --git a/rmw_cyclonedds_cpp/src/u16string.cpp b/rmw_cyclonedds_cpp/src/u16string.cpp
-index 562041a..e0565bc 100644
+index 562041a..9797b6b 100644
 --- a/rmw_cyclonedds_cpp/src/u16string.cpp
 +++ b/rmw_cyclonedds_cpp/src/u16string.cpp
-@@ -15,10 +15,31 @@
- #include <string>
- #include "rosidl_runtime_c/u16string_functions.h"
+@@ -12,13 +12,15 @@
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
  
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
+-#include <string>
+ #include "rosidl_runtime_c/u16string_functions.h"
 +#include <memory_resource>
 +#include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+  using u16string = std::experimental::pmr::u16string;
-+}
-+#endif
-+
+ 
  namespace rmw_cyclonedds_cpp
  {
  
@@ -409,7 +345,7 @@ index 562041a..e0565bc 100644
  {
    wstr.resize(u16str.size());
    for (size_t i = 0; i < u16str.size(); ++i) {
-@@ -26,7 +47,7 @@ void u16string_to_wstring(const std::u16string & u16str, std::wstring & wstr)
+@@ -26,7 +28,7 @@ void u16string_to_wstring(const std::u16string & u16str, std::wstring & wstr)
    }
  }
  
@@ -418,7 +354,7 @@ index 562041a..e0565bc 100644
  {
    try {
      u16str.resize(wstr.size());
-@@ -39,7 +60,7 @@ bool wstring_to_u16string(const std::wstring & wstr, std::u16string & u16str)
+@@ -39,7 +41,7 @@ bool wstring_to_u16string(const std::wstring & wstr, std::u16string & u16str)
    return true;
  }
  
@@ -427,7 +363,7 @@ index 562041a..e0565bc 100644
  {
    wstr.resize(u16str.size);
    for (size_t i = 0; i < u16str.size; ++i) {
-@@ -47,7 +68,7 @@ void u16string_to_wstring(const rosidl_runtime_c__U16String & u16str, std::wstri
+@@ -47,7 +49,7 @@ void u16string_to_wstring(const rosidl_runtime_c__U16String & u16str, std::wstri
    }
  }
  
@@ -437,33 +373,19 @@ index 562041a..e0565bc 100644
    bool succeeded = rosidl_runtime_c__U16String__resize(&u16str, wstr.size());
    if (!succeeded) {
 diff --git a/rmw_cyclonedds_cpp/src/u16string.hpp b/rmw_cyclonedds_cpp/src/u16string.hpp
-index 4019aa8..27f167d 100644
+index 4019aa8..a5bff18 100644
 --- a/rmw_cyclonedds_cpp/src/u16string.hpp
 +++ b/rmw_cyclonedds_cpp/src/u16string.hpp
-@@ -18,18 +18,39 @@
- #include <string>
+@@ -15,21 +15,24 @@
+ #ifndef U16STRING_HPP_
+ #define U16STRING_HPP_
+ 
+-#include <string>
  #include "rosidl_runtime_c/u16string_functions.h"
  
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
 +#include <memory_resource>
 +#include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+  using u16string = std::experimental::pmr::u16string;
-+}
-+#endif
 +
  namespace rmw_cyclonedds_cpp
  {

--- a/Patches/rmw_fastrtps.patch
+++ b/Patches/rmw_fastrtps.patch
@@ -11,38 +11,19 @@ index c30caa0..0b75973 100644
    fastcdr fastrtps)
  
 diff --git a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
-index 2708392..4fe5ce6 100644
+index 2708392..f672bb2 100644
 --- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
 +++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
-@@ -18,6 +18,27 @@
- #include <cassert>
- #include <string>
+@@ -16,6 +16,8 @@
+ #define RMW_FASTRTPS_DYNAMIC_CPP__TYPESUPPORT_HPP_
  
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
+ #include <cassert>
 +#include <memory_resource>
 +#include <vector>
-+#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+  using u16string = std::experimental::pmr::u16string;
-+}
-+#endif
-+
- #include "rosidl_runtime_c/string.h"
- #include "rosidl_runtime_c/string_functions.h"
+ #include <string>
  
-@@ -48,7 +69,7 @@ namespace rmw_fastrtps_dynamic_cpp
+ #include "rosidl_runtime_c/string.h"
+@@ -48,7 +50,7 @@ namespace rmw_fastrtps_dynamic_cpp
  template<typename MembersType>
  struct StringHelper;
  
@@ -51,7 +32,7 @@ index 2708392..4fe5ce6 100644
  // eprosima::fastcdr::Cdr can handle the string properly.
  template<>
  struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
-@@ -76,7 +97,7 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
+@@ -76,7 +78,7 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
      return current_alignment + strlen(c_string->data) + 1;
    }
  
@@ -60,7 +41,7 @@ index 2708392..4fe5ce6 100644
    {
      auto c_string = static_cast<rosidl_runtime_c__String *>(data);
      if (!c_string) {
-@@ -91,37 +112,37 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
+@@ -91,37 +93,37 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
          "rosidl_generator_c_String had invalid data");
        return "";
      }
@@ -108,38 +89,21 @@ index 2708392..4fe5ce6 100644
    }
  };
 diff --git a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
-index 899119f..e07548e 100644
+index 899119f..703bae3 100644
 --- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
 +++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
-@@ -19,6 +19,27 @@
- #include <string>
- #include <vector>
+@@ -16,8 +16,9 @@
+ #define RMW_FASTRTPS_DYNAMIC_CPP__TYPESUPPORT_IMPL_HPP_
  
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
+ #include <cassert>
+-#include <string>
 +#include <memory_resource>
-+#include <vector>
+ #include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  using string = std::experimental::pmr::string;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using wstring = std::experimental::pmr::wstring;
-+  using u16string = std::experimental::pmr::u16string;
-+}
-+#endif
-+
+ 
  #include "fastcdr/Cdr.h"
  #include "fastcdr/FastBuffer.h"
- #include "fastcdr/exceptions/Exception.h"
-@@ -81,21 +102,21 @@ void serialize_field(
+@@ -81,21 +82,21 @@ void serialize_field(
    } else if (member->array_size_ && !member->is_upper_bound_) {
      ser.serializeArray(static_cast<T *>(field), member->array_size_);
    } else {
@@ -165,7 +129,7 @@ index 899119f..e07548e 100644
      rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(*u16str, wstr);
      ser << wstr;
    } else {
-@@ -108,7 +129,7 @@ void serialize_field<std::wstring>(
+@@ -108,7 +109,7 @@ void serialize_field<std::wstring>(
      }
      for (size_t i = 0; i < size; ++i) {
        const void * element = member->get_const_function(field, i);
@@ -174,7 +138,7 @@ index 899119f..e07548e 100644
        rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(*u16str, wstr);
        ser << wstr;
      }
-@@ -134,7 +155,7 @@ void serialize_field(
+@@ -134,7 +135,7 @@ void serialize_field(
  
  template<>
  inline
@@ -183,7 +147,7 @@ index 899119f..e07548e 100644
    const rosidl_typesupport_introspection_c__MessageMember * member,
    void * field,
    eprosima::fastcdr::Cdr & ser)
-@@ -149,11 +170,11 @@ void serialize_field<std::string>(
+@@ -149,11 +150,11 @@ void serialize_field<std::string>(
      ser << str;
    } else {
      // First, cast field to rosidl_generator_c
@@ -197,7 +161,7 @@ index 899119f..e07548e 100644
        auto string_field = static_cast<rosidl_runtime_c__String *>(field);
        for (size_t i = 0; i < member->array_size_; ++i) {
          tmpstring = string_field[i].data;
-@@ -162,7 +183,7 @@ void serialize_field<std::string>(
+@@ -162,7 +163,7 @@ void serialize_field<std::string>(
      } else {
        auto & string_sequence_field =
          *reinterpret_cast<rosidl_runtime_c__String__Sequence *>(field);
@@ -206,7 +170,7 @@ index 899119f..e07548e 100644
        for (size_t i = 0; i < string_sequence_field.size; ++i) {
          cpp_string_vector.push_back(
            CStringHelper::convert_to_std_string(string_sequence_field.data[i]));
-@@ -174,12 +195,12 @@ void serialize_field<std::string>(
+@@ -174,12 +175,12 @@ void serialize_field<std::string>(
  
  template<>
  inline
@@ -221,7 +185,7 @@ index 899119f..e07548e 100644
    if (!member->is_array_) {
      auto u16str = static_cast<rosidl_runtime_c__U16String *>(field);
      rosidl_typesupport_fastrtps_c::u16string_to_wstring(*u16str, wstr);
-@@ -255,10 +276,10 @@ bool TypeSupport<MembersType>::serializeROSmessage(
+@@ -255,10 +256,10 @@ bool TypeSupport<MembersType>::serializeROSmessage(
          serialize_field<uint64_t>(member, field, ser);
          break;
        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
@@ -234,7 +198,7 @@ index 899119f..e07548e 100644
          break;
        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
          {
-@@ -315,7 +336,7 @@ size_t next_field_align(
+@@ -315,7 +316,7 @@ size_t next_field_align(
      current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
      current_alignment += item_size * member->array_size_;
    } else {
@@ -243,7 +207,7 @@ index 899119f..e07548e 100644
      current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
      current_alignment += padding;
      if (!data.empty()) {
-@@ -348,7 +369,7 @@ size_t next_field_align_string(
+@@ -348,7 +349,7 @@ size_t next_field_align_string(
        current_alignment += character_size * (str_arr[index].size() + 1);
      }
    } else {
@@ -252,7 +216,7 @@ index 899119f..e07548e 100644
      current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
      current_alignment += padding;
      for (auto & it : data) {
-@@ -394,7 +415,7 @@ size_t next_field_align_string(
+@@ -394,7 +395,7 @@ size_t next_field_align_string(
  
  template<>
  inline
@@ -261,7 +225,7 @@ index 899119f..e07548e 100644
    const rosidl_typesupport_introspection_c__MessageMember * member,
    void * field,
    size_t current_alignment)
-@@ -427,7 +448,7 @@ size_t next_field_align_string<std::string>(
+@@ -427,7 +428,7 @@ size_t next_field_align_string<std::string>(
  
  template<>
  inline
@@ -270,7 +234,7 @@ index 899119f..e07548e 100644
    const rosidl_typesupport_introspection_c__MessageMember * member,
    void * field,
    size_t current_alignment)
-@@ -512,10 +533,10 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
+@@ -512,10 +513,10 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
          current_alignment = next_field_align<uint64_t>(member, field, current_alignment);
          break;
        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
@@ -283,7 +247,7 @@ index 899119f..e07548e 100644
          break;
        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
          {
-@@ -570,39 +591,39 @@ void deserialize_field(
+@@ -570,39 +571,39 @@ void deserialize_field(
    } else if (member->array_size_ && !member->is_upper_bound_) {
      deser.deserializeArray(static_cast<T *>(field), member->array_size_);
    } else {
@@ -331,7 +295,7 @@ index 899119f..e07548e 100644
    } else {
      uint32_t size;
      if (member->array_size_ && !member->is_upper_bound_) {
-@@ -613,7 +634,7 @@ inline void deserialize_field<std::wstring>(
+@@ -613,7 +614,7 @@ inline void deserialize_field<std::wstring>(
      }
      for (size_t i = 0; i < size; ++i) {
        void * element = member->get_function(field, i);
@@ -340,7 +304,7 @@ index 899119f..e07548e 100644
        deser >> wstr;
        rosidl_typesupport_fastrtps_cpp::wstring_to_u16string(wstr, *u16str);
      }
-@@ -640,7 +661,7 @@ void deserialize_field(
+@@ -640,7 +641,7 @@ void deserialize_field(
  }
  
  template<>
@@ -349,7 +313,7 @@ index 899119f..e07548e 100644
    const rosidl_typesupport_introspection_c__MessageMember * member,
    void * field,
    eprosima::fastcdr::Cdr & deser)
-@@ -653,7 +674,7 @@ inline void deserialize_field<std::string>(
+@@ -653,7 +654,7 @@ inline void deserialize_field<std::string>(
        auto deser_field = static_cast<rosidl_runtime_c__String *>(field);
        // tmpstring is defined here and not below to avoid
        // memory allocation in every iteration of the for loop
@@ -358,7 +322,7 @@ index 899119f..e07548e 100644
        for (size_t i = 0; i < member->array_size_; ++i) {
          deser.deserialize(tmpstring);
          if (!rosidl_runtime_c__String__assign(&deser_field[i], tmpstring.c_str())) {
-@@ -661,7 +682,7 @@ inline void deserialize_field<std::string>(
+@@ -661,7 +662,7 @@ inline void deserialize_field<std::string>(
          }
        }
      } else {
@@ -367,7 +331,7 @@ index 899119f..e07548e 100644
        deser >> cpp_string_vector;
  
        auto & string_sequence_field =
-@@ -686,12 +707,12 @@ inline void deserialize_field<std::string>(
+@@ -686,12 +687,12 @@ inline void deserialize_field<std::string>(
  }
  
  template<>
@@ -382,7 +346,7 @@ index 899119f..e07548e 100644
    if (!member->is_array_) {
      deser >> wstr;
      rosidl_typesupport_fastrtps_c::wstring_to_u16string(
-@@ -765,10 +786,10 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
+@@ -765,10 +766,10 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
          deserialize_field<uint64_t>(member, field, deser);
          break;
        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:

--- a/Patches/rosidl.patch
+++ b/Patches/rosidl.patch
@@ -24,36 +24,17 @@ index 9e8f9f5..201cf4f 100644
  # That way if a package that generates interfaces also has a target depending
  # on those generated interfaces, that target will wait for this generator's
 diff --git a/rosidl_generator_cpp/resource/idl__struct.hpp.em b/rosidl_generator_cpp/resource/idl__struct.hpp.em
-index 602d47d..45ae890 100644
+index 602d47d..ab047c8 100644
 --- a/rosidl_generator_cpp/resource/idl__struct.hpp.em
 +++ b/rosidl_generator_cpp/resource/idl__struct.hpp.em
-@@ -26,8 +26,28 @@ include_directives = set()
+@@ -26,8 +26,9 @@ include_directives = set()
  #include <algorithm>
  #include <array>
  #include <memory>
 -#include <string>
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
 +#include <memory_resource>
  #include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+  template <class T>
-+  using polymorphic_allocator = std::experimental::pmr::polymorphic_allocator<T>;
-+  template <class _ValueT>
-+  using vector = std::experimental::pmr::vector<_ValueT>;
-+  using string = std::experimental::pmr::string;
-+  using wstring = std::experimental::pmr::wstring;
-+  using u16string = std::experimental::pmr::u16string;
-+}
-+#endif
  
  #include "rosidl_runtime_cpp/bounded_vector.hpp"
  #include "rosidl_runtime_cpp/message_initialization.hpp"
@@ -232,77 +213,23 @@ index c37b821..759f2d7 100644
          return "" == i;
        }));
  }
-diff --git a/rosidl_runtime_cpp/CMakeLists.txt b/rosidl_runtime_cpp/CMakeLists.txt
-index a588ddd..b1dc284 100644
---- a/rosidl_runtime_cpp/CMakeLists.txt
-+++ b/rosidl_runtime_cpp/CMakeLists.txt
-@@ -5,12 +5,16 @@ project(rosidl_runtime_cpp)
- find_package(ament_cmake REQUIRED)
- find_package(rosidl_runtime_c REQUIRED)
- 
-+add_library(experimental_memory_resource STATIC src/experimental_memory_resource.cpp)
-+#target_include_directories(experimental_memory_resource PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-+
- add_library(${PROJECT_NAME} INTERFACE)
- target_include_directories(${PROJECT_NAME} INTERFACE
-   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
- target_link_libraries(${PROJECT_NAME} INTERFACE
--  rosidl_runtime_c::rosidl_runtime_c)
-+  rosidl_runtime_c::rosidl_runtime_c
-+  experimental_memory_resource)
- 
- if(MSVC)
-   target_compile_definitions(${PROJECT_NAME} INTERFACE
-@@ -22,6 +26,7 @@ ament_export_include_directories("include/${PROJECT_NAME}")
- 
- # Export modern CMake targets
- ament_export_targets(${PROJECT_NAME})
-+#ament_export_targets(experimental_memory_resource)
- 
- ament_index_register_resource("rosidl_runtime_packages")
- 
-@@ -62,6 +67,9 @@ install(
-   DIRECTORY include/
-   DESTINATION include/${PROJECT_NAME}
- )
-+install(
-+  TARGETS experimental_memory_resource EXPORT ${PROJECT_NAME}
-+)
- install(
-   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
- )
 diff --git a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
-index 713aa66..2690770 100644
+index 713aa66..2af8a81 100644
 --- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
 +++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
-@@ -20,6 +20,25 @@
- #include <string>
- #include <type_traits>
+@@ -17,8 +17,10 @@
  
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#include <experimental/vector>
-+#include <experimental/string>
-+#else
+ #include <codecvt>
+ #include <iomanip>
+-#include <string>
+ #include <type_traits>
 +#include <memory_resource>
 +#include <vector>
 +#include <string>
-+#endif
-+
-+#ifdef __linux__
-+namespace std::pmr
-+{
-+using string = std::experimental::pmr::string;
-+using wstring = std::experimental::pmr::wstring;
-+using u16string = std::experimental::pmr::u16string;
-+}
-+#endif
-+
+ 
  namespace rosidl_generator_traits
  {
- 
-@@ -123,11 +142,69 @@ inline void value_to_yaml(const std::string & value, std::ostream & out)
+@@ -123,11 +125,69 @@ inline void value_to_yaml(const std::string & value, std::ostream & out)
    }
    out << "\"";
  }
@@ -373,56 +300,6 @@ index 713aa66..2690770 100644
    auto flags = out.flags();
    size_t index = 0;
    while (index < value.size()) {
-diff --git a/rosidl_runtime_cpp/src/experimental_memory_resource.cpp b/rosidl_runtime_cpp/src/experimental_memory_resource.cpp
-new file mode 100644
-index 0000000..53b6b41
---- /dev/null
-+++ b/rosidl_runtime_cpp/src/experimental_memory_resource.cpp
-@@ -0,0 +1,44 @@
-+#include <cstddef>
-+#include <cstdlib>
-+#include <new>
-+
-+#if __linux__
-+
-+namespace std {
-+namespace experimental {
-+namespace fundamentals_v1 {
-+namespace pmr {
-+
-+class memory_resource {
-+public:
-+    virtual ~memory_resource() = default;
-+    
-+protected:
-+    virtual void* do_allocate(size_t bytes, size_t alignment) = 0;
-+    virtual void do_deallocate(void* p, size_t bytes, size_t alignment) = 0;
-+    virtual bool do_is_equal(const memory_resource& other) const noexcept = 0;
-+};
-+
-+class default_resource_impl : public memory_resource {
-+protected:
-+    void* do_allocate(size_t bytes, size_t alignment) override {
-+        return ::operator new(bytes, std::align_val_t(alignment));
-+    }
-+
-+    void do_deallocate(void* p, size_t bytes, size_t alignment) override {
-+        ::operator delete(p, bytes, std::align_val_t(alignment));
-+    }
-+
-+    bool do_is_equal(const memory_resource& other) const noexcept override {
-+        return this == &other;
-+    }
-+};
-+
-+memory_resource* get_default_resource() noexcept {
-+    static default_resource_impl default_resource;
-+    return &default_resource;
-+}
-+
-+}}}} // namespaces
-+
-+#endif
 diff --git a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
 index 60cc226..8678c05 100644
 --- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em

--- a/Patches/rosidl_typesupport_fastrtps.patch
+++ b/Patches/rosidl_typesupport_fastrtps.patch
@@ -26,22 +26,18 @@ index 4a761ad..9f904b4 100644
  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBLIC
    fastcdr
 diff --git a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/wstring_conversion.hpp b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/wstring_conversion.hpp
-index ce85914..a517333 100644
+index ce85914..0891052 100644
 --- a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/wstring_conversion.hpp
 +++ b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/wstring_conversion.hpp
-@@ -16,6 +16,11 @@
+@@ -16,6 +16,7 @@
  #define ROSIDL_TYPESUPPORT_FASTRTPS_C__WSTRING_CONVERSION_HPP_
  
  #include <string>
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#else
 +#include <memory_resource>
-+#endif
  
  #include "rosidl_runtime_c/u16string.h"
  #include "rosidl_typesupport_fastrtps_c/visibility_control.h"
-@@ -28,9 +33,15 @@ namespace rosidl_typesupport_fastrtps_c
+@@ -28,9 +29,15 @@ namespace rosidl_typesupport_fastrtps_c
   * \param[in] u16str The 16-bit character string to copy from.
   * \param[in,out] wstr The std::wstring to copy to.
   */
@@ -59,7 +55,7 @@ index ce85914..a517333 100644
  
  /// Convert a std::wstring into a `rosidl_runtime_c__U16String`.
  /**
-@@ -38,9 +49,19 @@ void u16string_to_wstring(
+@@ -38,9 +45,19 @@ void u16string_to_wstring(
   * \param[in,out] u16str The u16string to copy to.
   * \return true if resizing u16str and assignment succeeded, otherwise false.
   */
@@ -215,22 +211,18 @@ index bfb6c9d..cf136a3 100644
  # Set compiler flags
  if(NOT WIN32)
 diff --git a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp
-index 35bc7c3..d2d411b 100644
+index 35bc7c3..750be66 100644
 --- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp
 +++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp
-@@ -18,6 +18,11 @@
+@@ -18,6 +18,7 @@
  #include <rosidl_typesupport_fastrtps_cpp/visibility_control.h>
  
  #include <string>
-+#ifdef __linux__
-+#include <experimental/memory_resource>
-+#else
 +#include <memory_resource>
-+#endif
  
  namespace rosidl_typesupport_fastrtps_cpp
  {
-@@ -27,8 +32,14 @@ namespace rosidl_typesupport_fastrtps_cpp
+@@ -27,8 +28,14 @@ namespace rosidl_typesupport_fastrtps_cpp
   * \param[in] u16str The std::u16string character string to copy from.
   * \param[in,out] wstr The std::wstring to copy to.
   */
@@ -247,7 +239,7 @@ index 35bc7c3..d2d411b 100644
  
  /// Convert a std::wstring into a std::u16string.
  /**
-@@ -36,8 +47,19 @@ void u16string_to_wstring(const std::u16string & u16str, std::wstring & wstr);
+@@ -36,8 +43,19 @@ void u16string_to_wstring(const std::u16string & u16str, std::wstring & wstr);
   * \param[in,out] u16str The std::u16string to copy to.
   * \return true if resizing u16str and assignment succeeded, otherwise false.
   */

--- a/Scripts/build_rclcpp_linux.sh
+++ b/Scripts/build_rclcpp_linux.sh
@@ -56,7 +56,7 @@ fi
 
 echo -e "Using Unreal Engine ThirdParty: $UE_THIRD_PARTY_PATH\n";
 
-LINUX_MULTIARCH_ROOT="$UNREAL_ENGINE_PATH/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7"
+LINUX_MULTIARCH_ROOT="$UNREAL_ENGINE_PATH/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v25_clang-18.1.0-rockylinux8"
 LINUX_ARCH_NAME="x86_64-unknown-linux-gnu"
 export UE_THIRD_PARTY_PATH="$UE_THIRD_PARTY_PATH"
 export LINUX_MULTIARCH_ROOT="$LINUX_MULTIARCH_ROOT"
@@ -157,7 +157,7 @@ cp -r "$ROOT_DIR/Source/rclcpp/asio/asio/include/asio.hpp" "$ROOT_DIR/Source/rcl
 echo -e "Building boost"
 cd "$ROOT_DIR/Source/rclcpp/boost"
 ./bootstrap.sh --prefix="$ROOT_DIR/Source/rclcpp/install"
-./b2 install toolset=clang-unreal --with-python --user-config="$ROOT_DIR/Source/rclcpp/boost_user_configs/boost-user-config-linux.jam" -d0 cxxflags="-std=c++11"
+./b2 install toolset=clang-unreal --with-python --user-config="$ROOT_DIR/Source/rclcpp/boost_user_configs/boost-user-config-linux.jam" -d0
 
 echo -e "Building ogg"
 cd "$ROOT_DIR/Source/rclcpp/ogg"
@@ -236,11 +236,11 @@ colcon build --packages-skip-by-dep python_qt_binding --packages-skip Boost Open
  " -DBUILD_TESTING=OFF" \
  " -DAsio_INCLUDE_DIR=$ROOT_DIR/Source/rclcpp/install/include/asio" \
  " -DTHIRDPARTY_Asio=FORCE" \
- " -DPNG_INCLUDE_DIRS='$UE_THIRD_PARTY_PATH/libPNG/libPNG-1.5.2'" \
- " -DPNG_LIBRARIES='$UE_THIRD_PARTY_PATH/libPNG/libPNG-1.5.2/lib/Unix/$LINUX_ARCH_NAME/libpng.a'" \
+ " -DPNG_INCLUDE_DIRS='$UE_THIRD_PARTY_PATH/libPNG/libPNG-1.6.44'" \
+ " -DPNG_LIBRARIES='$UE_THIRD_PARTY_PATH/libPNG/libPNG-1.6.44/lib/Unix/$LINUX_ARCH_NAME/libpng.a'" \
  " -DPNG_FOUND=ON" \
- " -DPNG_PNG_INCLUDE_DIR='$UE_THIRD_PARTY_PATH/libPNG/libPNG-1.5.2'" \
- " -DPNG_LIBRARY='$UE_THIRD_PARTY_PATH/libPNG/libPNG-1.5.2/lib/Unix/$LINUX_ARCH_NAME/libpng.a'" \
+ " -DPNG_PNG_INCLUDE_DIR='$UE_THIRD_PARTY_PATH/libPNG/libPNG-1.6.44'" \
+ " -DPNG_LIBRARY='$UE_THIRD_PARTY_PATH/libPNG/libPNG-1.6.44/lib/Unix/$LINUX_ARCH_NAME/libpng.a'" \
  " -DZLIB_LIBRARY='$UE_THIRD_PARTY_PATH/zlib/1.3/lib/Unix/$LINUX_ARCH_NAME/Release/libz.a'" \
  " -DZLIB_LIBRARIES='$UE_THIRD_PARTY_PATH/zlib/1.3/lib/Unix/$LINUX_ARCH_NAME/Release/libz.a'" \
  " -DZLIB_INCLUDE_DIR='$UE_THIRD_PARTY_PATH/zlib/1.3/include'" \

--- a/Source/rclcpp/boost_user_configs/boost-user-config-linux.jam
+++ b/Source/rclcpp/boost_user_configs/boost-user-config-linux.jam
@@ -8,6 +8,9 @@ local CLANG_TOOLCHAIN_ROOT = $(LINUX_MULTIARCH_ROOT)/$(LINUX_ARCH_NAME) ;
 local CLANG_TOOLCHAIN_BIN = $(CLANG_TOOLCHAIN_ROOT)/bin ;
 
 using clang : unreal : $(CLANG_TOOLCHAIN_BIN)/clang++ :
+    <cxxflags>-std=c++11
+    <cxxflags>-stdlib=libc++
+    <cxxflags>-nostdinc++
     <cxxflags>-isystem$(UE_THIRD_PARTY_PATH)/Unix/LibCxx/include/c++/v1
     <cxxflags>-fexceptions
     <cxxflags>-DPLATFORM_EXCEPTIONS_DISABLED=0

--- a/Toolchains/linux.toolchain.cmake
+++ b/Toolchains/linux.toolchain.cmake
@@ -36,13 +36,13 @@ include_directories("${UE_THIRD_PARTY_PATH}/Unix/LibCxx/include/c++/v1")
 include_directories("${CLANG_TOOLCHAIN_ROOT}/usr/include")
 
 # Library paths (use libc++, specifically the one that comes with Unreal)
-set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-stdlib=libc++ -nostdlib++ -lc++ -lc++abi")
 link_directories("${UE_THIRD_PARTY_PATH}/Unix/LibCxx/lib/Unix/${LINUX_ARCH_NAME}")
 
 # Compiler flags (chosen to match those Unreal uses as closely as possible)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(COMPILER_FLAGS " -fexceptions -DPLATFORM_EXCEPTIONS_DISABLED=0 -fmessage-length=0 \
-                     -fpascal-strings -fasm-blocks -ffp-contract=off \
+                     -fpascal-strings -fasm-blocks -ffp-contract=off -nostdinc++\
                      -fvisibility-inlines-hidden -fPIC --target=${LINUX_ARCH_NAME} -O3 -DNDEBUG \
                      --sysroot=${CLANG_TOOLCHAIN_ROOT} -fno-math-errno -fdiagnostics-format=msvc \
                      -funwind-tables -gdwarf-3 -pthread -Wno-unused-command-line-argument \


### PR DESCRIPTION
UE 5.5 and below on Linux had pmr::memory_resource in the experimental section of the C++ api. In 5.6 they moved it out of experimental. This removes the hoops we jumped through to get it to work from experimental on Linux, making it the same as the other platforms, and makes a couple more tweaks to get everything working right on 5.6.